### PR TITLE
Two fixes that allow using toml-d in a current environment

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,6 +6,6 @@
     "license": "BSL-1.0",
     "targetType" : "library",
 	"dependencies": {
-        "pegged": "~master"
+        "pegged": "0.2.1"
 	}
 }

--- a/source/toml/parser.d
+++ b/source/toml/parser.d
@@ -17,7 +17,7 @@ enum TOMLType {
 };
 
 class TOMLException: Exception {
-    this(string msg, string file="parser", ulong line=111) {
+    this(string msg, string file="parser", uint line=111) {
         super(msg, file, line);
     }
 }


### PR DESCRIPTION
These two commits fix a warning and en error I occurred using toml-d with the current versions of dmd and dub. See the commit messages for details.
