### PR TITLE
Really fix compilation on 32/64bit platforms

### DIFF
--- a/source/toml/parser.d
+++ b/source/toml/parser.d
@@ -17,7 +17,7 @@ enum TOMLType {
 };
 
 class TOMLException: Exception {
-    this(string msg, string file="parser", uint line=111) {
+    this(string msg, string file="parser", size_t line=111) {
         super(msg, file, line);
     }
 }


### PR DESCRIPTION
The previous commit 0cc11b1f01deacd8388287ac4d1c0e0f9329ed2d was wrong,
the third parameter must be of type size_t to compile on both 32 and 64
bit platforms.
